### PR TITLE
Fix the specified version number for SDK 1.0.1 in known-issues.md

### DIFF
--- a/known-issues.md
+++ b/known-issues.md
@@ -10,7 +10,7 @@ If you open a .NET Core project project and the corresponding .NET Core SDK is m
 
 To workaround this you can install the correct version of the .NET SDK. You can use the links below.
 
-#### .NET Core 1.0.1 SDK 1.0.0-preview2-003131 download links
+#### .NET Core 1.0.1 SDK 1.0.0-preview2-003133 download links
 
 | Platform    | Link          |
 |-------------|---------------|


### PR DESCRIPTION
The title was saying these were download links for *preview2-003131*.

The actual links download installers for *preview2-003133*.

I've updated the title to reflect what the links actually download.